### PR TITLE
Add cli-download-posts.js

### DIFF
--- a/lib/cli-download-posts.js
+++ b/lib/cli-download-posts.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const fsPromises = fs.promises;
+const tumblr = require('tumblr.js');
+
+let tumblrApiConfig = JSON.parse(fs.readFileSync(`./tumblr-api-config.json`, 'utf8'));
+
+let client = tumblr.createClient({
+    credentials: tumblrApiConfig,
+    returnPromises: true,
+});
+
+async function getPosts(blogName, params) {
+    console.log(`Retrieving posts before: ${new Date(Number(params.before) * 1000)} (${params})`);
+
+    let response = await client.blogPosts(blogName, params);
+
+    return {
+        response: response,
+        params: params
+    };
+}
+
+async function save(responseAndTimestamp) {
+    let {response, params} = responseAndTimestamp;
+
+    // Save the raw API response for posterity
+    await fsPromises.writeFile(`./posts-api-raw/page-${params.page_number}.json`, JSON.stringify(response), 'utf8');
+
+    // Save individual likes
+    console.log(`${response.posts.length} more posts retrieved.`);
+    for (let post of response.posts) {
+        await fsPromises.writeFile(`./posts-json/${post.id}.json`, JSON.stringify(post), 'utf8');
+    }
+
+    return response._links;
+}
+
+async function processTimestamp(blogName, params) {
+    getPosts(blogName, params)
+    .then(save)
+    .then(function(links) {
+        console.log(links);
+        if (links && links.hasOwnProperty('next')) {
+            // Recursive, so use setImmediate to break the call stack.
+            setImmediate(processTimestamp, blogName, links.next.query_params);
+        } else {
+            console.log('DONE: list of posts downloaded.\n');
+
+            console.log(`The next step is to download the images and video media from Tumblr.`);
+            // TODO: Implement downloader
+            // console.log(`Run this command next:`);
+            // console.log(`npm run get-likes-media`);
+        }
+
+        return;
+    })
+    .catch(function(err) {
+        console.log(err);
+    });
+}
+
+processTimestamp(process.argv[2], {
+    before: Math.floor(Date.now() / 1000),
+    limit: '20',
+    offset: '0',
+    page_number: '0'
+})


### PR DESCRIPTION
This is rather rough, and doesn't really work nicely for non-technical users, but it does download posts from the given blog; the only challenge is dealing with API rate limits, currently it just crashes when it hits them, and then you have to update the `processTimestamp` line with the new parameters and re-run it in a while. But it works. It should hopefully also be compatible with the get-likes-media script.

I figured I'd share this back, just in case anyone's looking for it.